### PR TITLE
A20 Fix: Disable interpolation values that are already interpolated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63411eeb8effe7946a836775d9364c38bd9c509f3423ab87b969949d348774c7"
+checksum = "f37fdd5603c721b8d090e22369940d65e74b70348bf76e8efefdb761950847f2"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heraclitus-compiler = "1.2.2"
+heraclitus-compiler = "1.2.5"
 similar-string = "1.4.2"
 colored = "2.0.0"

--- a/out.sh
+++ b/out.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-a=1;
-echo "$(echo 1+1 | bc -l)"
+echo $(echo test )

--- a/out.sh
+++ b/out.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-echo test
+a=1;
+echo "$(echo 1+1 | bc -l)"

--- a/out.sh
+++ b/out.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-echo $(echo test )
+a=12;
+a=12

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,7 +9,7 @@ use crate::rules;
 use flag_registry::FlagRegistry;
 use std::env;
 use std::os::unix::prelude::PermissionsExt;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::{io, io::prelude::*};
 use std::fs;
 
@@ -115,22 +115,14 @@ impl CLI {
             let mut meta = ParserMetadata::new(tokens, path.clone(), Some(code.clone()));
             if let Ok(()) = block.parse(&mut meta) {
                 let mut meta = TranslateMetadata::new();
-                return format!("#!/bin/bash\n{}", block.translate(&mut meta));
+                return format!("{}", block.translate(&mut meta));
             }
         }
         format!("[err]")
     }
 
     fn execute(&self, code: String) {
-        let child = Command::new(format!("/bin/bash"))
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn().unwrap();
-        write!(child.stdin.as_ref().unwrap(), "{}", code).unwrap();
-        let out = child.wait_with_output().unwrap().stdout.clone();
-        let out = String::from_utf8_lossy(&out);
-        println!("{}", out);
+        Command::new(format!("/bin/bash")).arg("-c").arg(code).spawn().unwrap().wait().unwrap();
     }
 
     #[inline]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,7 +15,6 @@ use std::fs;
 
 pub struct CLI {
     args: Vec<String>,
-    path: Option<String>,
     flags: FlagRegistry,
     name: String,
     exe_name: String,
@@ -28,7 +27,6 @@ impl CLI {
     pub fn new() -> Self {
         CLI {
             args: vec![],
-            path: None,
             flags: FlagRegistry::new(),
             name: format!("Amber"),
             exe_name: format!("amber"),
@@ -112,12 +110,9 @@ impl CLI {
         let rules = rules::get_rules();
         let mut cc = Compiler::new("Amber", rules);
         let mut block = block::Block::new();
-        cc.load(code);
-        if let Some(path) = path {
-            cc.set_path(path);
-        }
+        cc.load(code.clone());
         if let Ok(tokens) = cc.tokenize() {
-            let mut meta = ParserMetadata::new(tokens, self.path.clone());
+            let mut meta = ParserMetadata::new(tokens, path.clone(), Some(code.clone()));
             if let Ok(()) = block.parse(&mut meta) {
                 let mut meta = TranslateMetadata::new();
                 return format!("#!/bin/bash\n{}", block.translate(&mut meta));

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -29,8 +29,14 @@ impl SyntaxModule<ParserMetadata> for Block {
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         meta.var_mem.push_scope();
         loop {
-            if let None = meta.get_token_at(meta.get_index()) {
-                break;
+            match meta.get_current_token() {
+                Some(token) => {
+                    if ["\n", ";"].contains(&token.word.as_str()) {
+                        meta.increment_index();
+                        continue;
+                    }
+                }
+                None => break
             }
             let mut statemant = Statement::new();
             if let Err(details) = statemant.parse(meta) {

--- a/src/modules/command/expr.rs
+++ b/src/modules/command/expr.rs
@@ -3,25 +3,25 @@ use crate::{utils::{ParserMetadata, TranslateMetadata}, modules::{Type, Typed}};
 use crate::modules::expression::expr::Expr;
 use crate::translate::module::TranslateModule;
 
-use super::{parse_interpolated_region, translate_interpolated_region};
+use crate::modules::expression::literal::{parse_interpolated_region, translate_interpolated_region};
 
 #[derive(Debug)]
-pub struct Command {
+pub struct CommandExpr {
     strings: Vec<String>,
     interps: Vec<Expr>
 }
 
-impl Typed for Command {
+impl Typed for CommandExpr {
     fn get_type(&self) -> Type {
         Type::Text
     }
 }
 
-impl SyntaxModule<ParserMetadata> for Command {
-    syntax_name!("Command");
+impl SyntaxModule<ParserMetadata> for CommandExpr {
+    syntax_name!("CommandExpr");
 
     fn new() -> Self {
-        Command {
+        CommandExpr {
             strings: vec![],
             interps: vec![]
         }
@@ -33,12 +33,12 @@ impl SyntaxModule<ParserMetadata> for Command {
     }
 }
 
-impl TranslateModule for Command {
+impl TranslateModule for CommandExpr {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         // Translate all interpolations
         let interps = self.interps.iter()
             .map(|item| item.translate(meta))
             .collect::<Vec<String>>();
-        format!("{}", translate_interpolated_region(self.strings.clone(), interps.clone()))
+        format!("$({})", translate_interpolated_region(self.strings.clone(), interps.clone()))
     }
 }

--- a/src/modules/command/mod.rs
+++ b/src/modules/command/mod.rs
@@ -1,0 +1,2 @@
+pub mod expr;
+pub mod statement;

--- a/src/modules/command/statement.rs
+++ b/src/modules/command/statement.rs
@@ -1,0 +1,44 @@
+use heraclitus_compiler::prelude::*;
+use crate::{utils::{ParserMetadata, TranslateMetadata}, modules::{Type, Typed}};
+use crate::modules::expression::expr::Expr;
+use crate::translate::module::TranslateModule;
+
+use crate::modules::expression::literal::{parse_interpolated_region, translate_interpolated_region};
+
+#[derive(Debug)]
+pub struct CommandStatement {
+    strings: Vec<String>,
+    interps: Vec<Expr>
+}
+
+impl Typed for CommandStatement {
+    fn get_type(&self) -> Type {
+        Type::Text
+    }
+}
+
+impl SyntaxModule<ParserMetadata> for CommandStatement {
+    syntax_name!("CommandStatement");
+
+    fn new() -> Self {
+        CommandStatement {
+            strings: vec![],
+            interps: vec![]
+        }
+    }
+
+    fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        (self.strings, self.interps) = parse_interpolated_region(meta, '$')?;
+        Ok(())
+    }
+}
+
+impl TranslateModule for CommandStatement {
+    fn translate(&self, meta: &mut TranslateMetadata) -> String {
+        // Translate all interpolations
+        let interps = self.interps.iter()
+            .map(|item| item.translate(meta))
+            .collect::<Vec<String>>();
+        format!("{}", translate_interpolated_region(self.strings.clone(), interps.clone()))
+    }
+}

--- a/src/modules/expression/binop/add.rs
+++ b/src/modules/expression/binop/add.rs
@@ -8,13 +8,12 @@ use crate::modules::{Type, Typed};
 #[derive(Debug)]
 pub struct Add {
     left: Box<Expr>,
-    right: Box<Expr>,
-    kind: Type
+    right: Box<Expr>
 }
 
 impl Typed for Add {
     fn get_type(&self) -> Type {
-        self.kind.clone()
+        Type::Num
     }
 }
 
@@ -24,8 +23,7 @@ impl SyntaxModule<ParserMetadata> for Add {
     fn new() -> Self {
         Add {
             left: Box::new(Expr::new()),
-            right: Box::new(Expr::new()),
-            kind: Type::Num
+            right: Box::new(Expr::new())
         }
     }
 

--- a/src/modules/expression/binop/div.rs
+++ b/src/modules/expression/binop/div.rs
@@ -7,13 +7,12 @@ use crate::translate::module::TranslateModule;
 #[derive(Debug)]
 pub struct Div {
     left: Box<Expr>,
-    right: Box<Expr>,
-    kind: Type
+    right: Box<Expr>
 }
 
 impl Typed for Div {
     fn get_type(&self) -> Type {
-        self.kind.clone()
+        Type::Num
     }
 }
 
@@ -23,8 +22,7 @@ impl SyntaxModule<ParserMetadata> for Div {
     fn new() -> Self {
         Div {
             left: Box::new(Expr::new()),
-            right: Box::new(Expr::new()),
-            kind: Type::Void
+            right: Box::new(Expr::new())
         }
     }
 

--- a/src/modules/expression/binop/mul.rs
+++ b/src/modules/expression/binop/mul.rs
@@ -25,7 +25,7 @@ impl SyntaxModule<ParserMetadata> for Mul {
         Mul {
             left: Box::new(Expr::new()),
             right: Box::new(Expr::new()),
-            kind: Type::Void
+            kind: Type::Null
         }
     }
 

--- a/src/modules/expression/binop/sub.rs
+++ b/src/modules/expression/binop/sub.rs
@@ -8,13 +8,12 @@ use crate::modules::{Type, Typed};
 #[derive(Debug)]
 pub struct Sub {
     left: Box<Expr>,
-    right: Box<Expr>,
-    kind: Type
+    right: Box<Expr>
 }
 
 impl Typed for Sub {
     fn get_type(&self) -> Type {
-        self.kind.clone()
+        Type::Num
     }
 }
 
@@ -24,8 +23,7 @@ impl SyntaxModule<ParserMetadata> for Sub {
     fn new() -> Self {
         Sub {
             left: Box::new(Expr::new()),
-            right: Box::new(Expr::new()),
-            kind: Type::Void
+            right: Box::new(Expr::new())
         }
     }
 

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -1,6 +1,7 @@
 use heraclitus_compiler::prelude::*;
 use crate::modules::{Typed, Type};
 use crate::translate::module::TranslateModule;
+use crate::utils::error::get_error_logger;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use super::literal::{
     bool::Bool,
@@ -73,8 +74,8 @@ impl Expr {
         // Arithmetic operators
         Add, Sub, Mul, Div,
         // Literals
-        VariableGet, Parenthesis,
-        CommandExpr, Bool, Number, Text
+        Parenthesis, CommandExpr, Bool, Number, Text,
+        VariableGet
     ]);
 
     // Get result out of the provided module and save it in the internal state
@@ -92,6 +93,12 @@ impl Expr {
             Err(details) => Err(details)
         }
     }
+
+    fn error(&self, meta: &mut ParserMetadata) {
+        get_error_logger(meta, ErrorDetails::from_metadata(meta))
+            .attach_message("Expected expression")
+            .show().exit();
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for Expr {
@@ -100,7 +107,7 @@ impl SyntaxModule<ParserMetadata> for Expr {
     fn new() -> Self {
         Expr {
             value: None,
-            kind: Type::Void
+            kind: Type::Null
         }
     }
 
@@ -113,6 +120,7 @@ impl SyntaxModule<ParserMetadata> for Expr {
                 Err(details) => error = Some(details)
             }
         }
+        self.error(meta);
         Err(error.unwrap())
     }
 }

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -5,8 +5,7 @@ use crate::utils::{ParserMetadata, TranslateMetadata};
 use super::literal::{
     bool::Bool,
     number::Number,
-    text::Text,
-    command::Command
+    text::Text
 };
 use super::binop::{
     add::Add,
@@ -27,6 +26,7 @@ use super::unop::{
 };
 use super::parenthesis::Parenthesis;
 use crate::modules::variable::get::VariableGet;
+use crate::modules::command::expr::CommandExpr;
 use crate::handle_types;
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ pub enum ExprType {
     Bool(Bool),
     Number(Number),
     Text(Text),
-    Command(Command),
+    CommandExpr(CommandExpr),
     Parenthesis(Parenthesis),
     VariableGet(VariableGet),
     Add(Add),
@@ -74,7 +74,7 @@ impl Expr {
         Add, Sub, Mul, Div,
         // Literals
         VariableGet, Parenthesis,
-        Command, Bool, Number, Text
+        CommandExpr, Bool, Number, Text
     ]);
 
     // Get result out of the provided module and save it in the internal state

--- a/src/modules/expression/literal/mod.rs
+++ b/src/modules/expression/literal/mod.rs
@@ -7,7 +7,6 @@ pub mod bool;
 pub mod number;
 pub mod text;
 pub mod void;
-pub mod command;
 
 pub fn parse_interpolated_region(meta: &mut ParserMetadata, letter: char) -> Result<(Vec<String>, Vec<Expr>), ErrorDetails> {
     let mut strings = vec![];
@@ -68,12 +67,7 @@ pub fn translate_interpolated_region(strings: Vec<String>, interps: Vec<String>)
         match value {
             Some(translated) => {
                 if is_even {
-                    if translated.starts_with('$') {
-                        result.push(format!("{translated}"));
-                    }
-                    else {
-                        result.push(format!("${{{translated}}}"))
-                    }
+                    result.push(format!("{translated}"));
                 } else {
                     result.push(translated)
                 }

--- a/src/modules/expression/literal/mod.rs
+++ b/src/modules/expression/literal/mod.rs
@@ -68,7 +68,12 @@ pub fn translate_interpolated_region(strings: Vec<String>, interps: Vec<String>)
         match value {
             Some(translated) => {
                 if is_even {
-                    result.push(format!("{{{translated}}}"))
+                    if translated.starts_with('$') {
+                        result.push(format!("{translated}"));
+                    }
+                    else {
+                        result.push(format!("${{{translated}}}"))
+                    }
                 } else {
                     result.push(translated)
                 }

--- a/src/modules/expression/literal/null.rs
+++ b/src/modules/expression/literal/null.rs
@@ -3,28 +3,28 @@ use crate::{utils::{ParserMetadata, TranslateMetadata}, modules::{Type, Typed}};
 use crate::translate::module::TranslateModule;
 
 #[derive(Debug)]
-pub struct Void {}
+pub struct Null {}
 
-impl Typed for Void {
+impl Typed for Null {
     fn get_type(&self) -> Type {
-        Type::Void
+        Type::Null
     }
 }
 
-impl SyntaxModule<ParserMetadata> for Void {
-    syntax_name!("Void");
+impl SyntaxModule<ParserMetadata> for Null {
+    syntax_name!("Null");
 
     fn new() -> Self {
-        Void {}
+        Null {}
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
-        token(meta, "void")?;
+        token(meta, "null")?;
         Ok(())        
     }
 }
 
-impl TranslateModule for Void {
+impl TranslateModule for Null {
     fn translate(&self, _meta: &mut TranslateMetadata) -> String {
         format!("''")
     }

--- a/src/modules/expression/literal/text.rs
+++ b/src/modules/expression/literal/text.rs
@@ -39,6 +39,6 @@ impl TranslateModule for Text {
         let interps = self.interps.iter()
             .map(|item| item.translate(meta))
             .collect::<Vec<String>>();
-        format!("'{}'", translate_interpolated_region(self.strings.clone(), interps.clone()))
+        format!("\"{}\"", translate_interpolated_region(self.strings.clone(), interps.clone()))
     }
 }

--- a/src/modules/expression/parenthesis.rs
+++ b/src/modules/expression/parenthesis.rs
@@ -21,7 +21,7 @@ impl SyntaxModule<ParserMetadata> for Parenthesis {
     fn new() -> Self {
         Parenthesis {
             value: Box::new(Expr::new()),
-            kind: Type::Void
+            kind: Type::Null
         }
     }
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -38,7 +38,7 @@ pub enum Type {
     Text,
     Bool,
     Num,
-    Void
+    Null
 }
 
 trait Typed {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,6 +2,7 @@ pub mod statement;
 pub mod expression;
 pub mod block;
 pub mod variable;
+pub mod command;
 
 #[macro_export]
 macro_rules! handle_types {

--- a/src/modules/statement/statement.rs
+++ b/src/modules/statement/statement.rs
@@ -6,13 +6,15 @@ use crate::modules::variable::{
     init::VariableInit,
     set::VariableSet
 };
+use crate::modules::command::statement::CommandStatement;
 use crate::handle_types;
 
 #[derive(Debug)]
 enum StatementType {
     Expr(Expr),
     VariableInit(VariableInit),
-    VariableSet(VariableSet)
+    VariableSet(VariableSet),
+    CommandStatement(CommandStatement)
 }
 
 #[derive(Debug)]
@@ -24,6 +26,8 @@ impl Statement {
     handle_types!(StatementType, [
         // Variables
         VariableInit, VariableSet,
+        // Command
+        CommandStatement,
         // Expression
         Expr
     ]);

--- a/src/modules/statement/statement.rs
+++ b/src/modules/statement/statement.rs
@@ -72,6 +72,9 @@ impl SyntaxModule<ParserMetadata> for Statement {
 
 impl TranslateModule for Statement {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        self.translate_match(meta, &self.value.as_ref().unwrap())
+        let translated = self.translate_match(meta, &self.value.as_ref().unwrap());
+        if translated.starts_with("$(") {
+            format!("echo {} > /dev/null 2>&1", translated)
+        } else { translated }
     }
 }

--- a/src/modules/variable/get.rs
+++ b/src/modules/variable/get.rs
@@ -21,7 +21,7 @@ impl SyntaxModule<ParserMetadata> for VariableGet {
     fn new() -> Self {
         VariableGet {
             name: format!(""),
-            kind: Type::Void
+            kind: Type::Null
         }
     }
 

--- a/src/modules/variable/mod.rs
+++ b/src/modules/variable/mod.rs
@@ -22,7 +22,7 @@ pub fn handle_variable_reference(meta: &mut ParserMetadata, token: Option<Token>
                 error = error.attach_comment(comment);
             }
             error.show().exit();
-            Type::Void
+            Type::Null
         }
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -2,7 +2,7 @@ use heraclitus_compiler::prelude::*;
 
 pub fn get_rules() -> Rules {
     let symbols = vec![
-        '+', '-', '*', '/',
+        '+', '-', '*', '/', '\n', ';',
         '(', ')', '[', ']', '{', '}'
     ];
     let compounds = vec![

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -39,7 +39,7 @@ pub fn translate_computation(meta: &mut TranslateMetadata, operation: ArithOp, l
                 ArithOp::And => "&&",
                 ArithOp::Or => "||"
             };
-            format!("$(echo {left} {op} {right} | bc -l)")
+            format!("$(echo {left} '{op}' {right} | bc -l)")
         }
     }
 }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -1,11 +1,8 @@
 use heraclitus_compiler::prelude::*;
 use crate::utils::metadata::ParserMetadata;
 
-pub fn get_error_logger(meta: &mut ParserMetadata, mut details: ErrorDetails) -> Logger {
-    if let Some(path) = meta.path.clone() {
-        if let Ok(location) = details.get_pos_by_file(&path) {
-            return Logger::new_err(path, location)
-        }
-    }
-    Logger::new_err_msg(format!("Error at {:?}", details.position))
+pub fn get_error_logger(meta: &mut ParserMetadata, details: ErrorDetails) -> Logger {
+    let path = meta.path.clone();
+    let code = meta.code.clone();
+    Logger::new_err_with_details(path, code, details)
 }

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -5,20 +5,22 @@ pub struct ParserMetadata {
     pub expr: Vec<Token>,
     index: usize,
     pub path: Option<String>,
+    pub code: Option<String>,
     pub binop_border: Option<usize>,
     pub var_mem: VariableMemory,
     debug: Option<usize>
 }
 
 impl Metadata for ParserMetadata {
-    fn new(expression: Vec<Token>, path: Option<String>) -> Self {
+    fn new(tokens: Vec<Token>, path: Option<String>, code: Option<String>) -> Self {
         ParserMetadata {
-            expr: expression,
+            expr: tokens,
             index: 0,
             path,
+            code,
             binop_border: None,
-            debug: None,
-            var_mem: VariableMemory::new()
+            var_mem: VariableMemory::new(),
+            debug: None
         }
     }
 

--- a/test.amber
+++ b/test.amber
@@ -1,1 +1,6 @@
-$echo test$
+let a = 1
+let b = 12.2
+let b = '12 + {a + 5} + 3'
+let c = '1 + 2'
+let d = this + 1
+$echo {d}$

--- a/test.amber
+++ b/test.amber
@@ -1,6 +1,3 @@
-let a = 1
-let b = 12.2
-let b = '12 + {a + 5} + 3'
-let c = '1 + 2'
-let d = this + 1
-$echo {d}$
+let a = 'this is a tets'
+
+$echo {a}$

--- a/test.amber
+++ b/test.amber
@@ -1,3 +1,3 @@
-let a = 'this is a tets'
-
+let a = 12
+a = a + 12
 $echo {a}$


### PR DESCRIPTION
Currently `$echo {1 + 1}$` results in an error. This is due to the fact that we are nesting code substitution inside of interpolation: `${$(...)}`