### PR TITLE
A32 Fix: Nested command evaluation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -124,6 +124,15 @@ mod tests {
     }
 
     #[test]
+    fn command_inception() {
+        let cli = CLI::new();
+        let code = "
+        ${${${$echo Hello World$}$}$}$
+        ";
+        assert_eq!(cli.test_eval(code).trim(), "Hello World");
+    }
+
+    #[test]
     fn comment() {
         let cli = CLI::new();
         let code = "

--- a/src/modules/command/statement.rs
+++ b/src/modules/command/statement.rs
@@ -39,6 +39,12 @@ impl TranslateModule for CommandStatement {
         let interps = self.interps.iter()
             .map(|item| item.translate(meta))
             .collect::<Vec<String>>();
-        translate_interpolated_region(self.strings.clone(), interps, false)
+        let mut translation = translate_interpolated_region(self.strings.clone(), interps, false);
+        // Strip down all the inner command interpolations [A32]
+        while translation.starts_with("$(") {
+            let end = translation.len() - 1;
+            translation = translation.get(2..end).unwrap().to_string();
+        }
+        translation
     }
 }


### PR DESCRIPTION
This expression should give the following result (`echo "Hello World"`)
```
${${${$echo "Hello World"$}$}$}$
```