### PR TITLE
A45 Feature: Functions shall have local variables

### DIFF
--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -9,10 +9,12 @@ pub struct Block {
 }
 
 impl Block {
+    // Get whether this block is empty
     pub fn is_empty(&self) -> bool {
         self.statements.is_empty()
     }
 
+    // Push a parsed statement into the block
     pub fn push_statement(&mut self, statement: Statement) {
         self.statements.push(statement);
     }

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -9,8 +9,10 @@ fn run_function_with_args(meta: &mut ParserMetadata, name: &str, args: &[Type]) 
     let mut block = Block::new();
     // Create a new parser metadata specific for the function parsing context
     let mut new_meta = meta.clone();
+    let function_ctx = new_meta.function_ctx;
     new_meta.expr = function.body.clone();
     new_meta.set_index(0);
+    new_meta.function_ctx = true;
     // Create a sub context for new variables
     new_meta.mem.push_scope();
     for (kind, (name, _generic)) in args.iter().zip(function.args.iter()) {
@@ -20,6 +22,7 @@ fn run_function_with_args(meta: &mut ParserMetadata, name: &str, args: &[Type]) 
     if let Ok(()) = syntax(&mut new_meta, &mut block) {
         // Pop function body
         new_meta.mem.pop_scope();
+        new_meta.function_ctx = function_ctx;
         // Persist the new function instance
         meta.mem.add_function_instance(function.id, args, Type::Text,  block)
     } else { 0 }

--- a/src/modules/variable/init.rs
+++ b/src/modules/variable/init.rs
@@ -10,7 +10,8 @@ use super::{variable_name_extensions, handle_identifier_name};
 #[derive(Debug, Clone)]
 pub struct VariableInit {
     name: String,
-    expr: Box<Expr>
+    expr: Box<Expr>,
+    function_ctx: bool
 }
 
 impl VariableInit {
@@ -26,7 +27,8 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
     fn new() -> Self {
         VariableInit {
             name: String::new(),
-            expr: Box::new(Expr::new())
+            expr: Box::new(Expr::new()),
+            function_ctx: false
         }
     }
 
@@ -35,6 +37,7 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
         // Get the variable name
         let tok = meta.get_current_token();
         self.name = variable(meta, variable_name_extensions())?;
+        self.function_ctx = meta.function_ctx;
         context!({
             token(meta, "=")?;
             syntax(meta, &mut *self.expr)?;
@@ -56,6 +59,10 @@ impl TranslateModule for VariableInit {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
         let expr = self.expr.translate(meta);
-        format!("{name}={expr}")
+        if self.function_ctx {
+            format!("local {name}={expr}")
+        } else {
+            format!("{name}={expr}")
+        }
     }
 }

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -10,7 +10,8 @@ pub struct ParserMetadata {
     pub binop_border: Option<usize>,
     pub mem: Memory,
     debug: Option<usize>,
-    pub loop_ctx: bool
+    pub loop_ctx: bool,
+    pub function_ctx: bool
 }
 
 impl Metadata for ParserMetadata {
@@ -23,7 +24,8 @@ impl Metadata for ParserMetadata {
             binop_border: None,
             mem: Memory::new(),
             debug: None,
-            loop_ctx: false
+            loop_ctx: false,
+            function_ctx: false
         }
     }
 


### PR DESCRIPTION
Amber code should convert
```
fun foo() {
    let a = 12
}
```

```bash
function foo {
    local a = 12
}
```