### PR TITLE
A40 Feature: Add main block

### DIFF
--- a/src/cli/cli_interface.rs
+++ b/src/cli/cli_interface.rs
@@ -43,7 +43,7 @@ impl CLI {
             match self.flags.get_flag("-e").unwrap().value.clone() {
                 Some(code) => {
                     match AmberCompiler::new(code, None).compile() {
-                        Ok(code) => AmberCompiler::execute(code),
+                        Ok(code) => AmberCompiler::execute(code, self.flags.get_args()),
                         Err(err) => {
                             err.show();
                             std::process::exit(1);
@@ -71,7 +71,7 @@ impl CLI {
                             }
                             // Execute the code
                             else {
-                                AmberCompiler::execute(code);
+                                AmberCompiler::execute(code, self.flags.get_args());
                             }
                         },
                         Err(err) => {

--- a/src/cli/flag_registry.rs
+++ b/src/cli/flag_registry.rs
@@ -17,7 +17,8 @@ impl Flag {
 }
 
 pub struct FlagRegistry {
-    flags: HashMap<String, Flag>
+    flags: HashMap<String, Flag>,
+    args: Vec<String>
 }
 
 impl Default for FlagRegistry {
@@ -30,13 +31,19 @@ impl FlagRegistry {
     #[inline]
     pub fn new() -> Self {
         FlagRegistry {
-            flags: HashMap::new()
+            flags: HashMap::new(),
+            args: vec![]
         }
     }
 
     #[inline]
     pub fn get_flag(&self, name: impl AsRef<str>) -> Option<&Flag> {
         self.flags.get(name.as_ref())
+    }
+
+    #[inline]
+    pub fn get_args(&self) -> &Vec<String> {
+        &self.args
     }
 
     #[inline]
@@ -55,7 +62,12 @@ impl FlagRegistry {
     pub fn parse(&mut self, args: Vec<String>) -> Vec<String> {
         let mut result = vec![];
         let mut is_value_flag = None;
+        let mut is_args = false;
         for arg in args.iter() {
+            if is_args {
+                self.args.push(arg.clone());
+                continue;
+            }
             if let Some(name) = &is_value_flag {
                 let flag = self.flags.get_mut(name).unwrap();
                 flag.value = Some(arg.clone());
@@ -66,6 +78,10 @@ impl FlagRegistry {
                 if flag.takes_value {
                     is_value_flag = Some(arg.clone());
                 }
+                continue
+            }
+            if arg == "--" {
+                is_args = true;
                 continue
             }
             result.push(arg.to_string())

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -83,7 +83,8 @@ impl AmberCompiler {
             .map(|(block, meta)| self.translate(block, meta))
     }
 
-    pub fn execute(code: String) {
+    pub fn execute(code: String, flags: &[String]) {
+        let code = format!("set -- {};\n\n{}", flags.join(" "), code);
         Command::new("/bin/bash").arg("-c").arg(code).spawn().unwrap().wait().unwrap();
     }
 

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -5,18 +5,13 @@ use super::statement::stmt::Statement;
 
 #[derive(Debug, Clone)]
 pub struct Block {
-    statements: Vec<Statement>,
-    is_scope: bool
+    statements: Vec<Statement>
 }
 
 impl Block {
     // Get whether this block is empty
     pub fn is_empty(&self) -> bool {
         self.statements.is_empty()
-    }
-
-    pub fn set_scopeless(&mut self) {
-        self.is_scope = false;
     }
 
     // Push a parsed statement into the block
@@ -30,8 +25,7 @@ impl SyntaxModule<ParserMetadata> for Block {
 
     fn new() -> Self {
         Block {
-            statements: vec![],
-            is_scope: true
+            statements: vec![]
         }
     }
 
@@ -68,16 +62,17 @@ impl SyntaxModule<ParserMetadata> for Block {
 
 impl TranslateModule for Block {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        if self.is_scope { meta.increase_indent(); }
+        meta.increase_indent();
         let result = if self.is_empty() {
             ":".to_string()
         }
         else {
             self.statements.iter()
-                .map(|module| meta.gen_indent() + &module.translate(meta))
+                .map(|statement| meta.gen_indent() + &statement.translate(meta))
+                .filter(|translation| !translation.trim().is_empty())
                 .collect::<Vec<_>>().join(";\n")
         };
-        if self.is_scope { meta.decrease_indent(); }
+        meta.decrease_indent();
         result
     }
 }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -29,7 +29,6 @@ impl SyntaxModule<ParserMetadata> for IfChain {
         loop {
             let mut cond = Expr::new();
             let mut block = Block::new();
-            cond.cannot_fail();
             // Handle comments and empty lines
             if token_by(meta, |token| token.starts_with('#') || token.starts_with('\n')).is_ok() {
                 continue

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -61,7 +61,6 @@ pub enum ExprType {
 #[derive(Debug, Clone)]
 pub struct Expr {
     value: Option<ExprType>,
-    can_fail: bool,
     kind: Type
 }
 
@@ -89,10 +88,6 @@ impl Expr {
         VariableGet
     ]);
 
-    pub fn cannot_fail(&mut self) {
-        self.can_fail = false;
-    }
-
     // Get result out of the provided module and save it in the internal state
     fn get<S>(&mut self, meta: &mut ParserMetadata, mut module: S, cb: impl Fn(S) -> ExprType) -> SyntaxResult
     where
@@ -116,8 +111,7 @@ impl SyntaxModule<ParserMetadata> for Expr {
     fn new() -> Self {
         Expr {
             value: None,
-            kind: Type::Null,
-            can_fail: true
+            kind: Type::Null
         }
     }
 

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -64,20 +64,22 @@ impl Import {
     fn handle_import(&mut self, meta: &mut ParserMetadata, tok: Option<Token>, imported_code: String) -> SyntaxResult {
         match AmberCompiler::new(imported_code.clone(), meta.path.clone()).tokenize() {
             Ok(tokens) => {
-                self.block.set_scopeless();
                 // Save snapshot of current file
                 let code = meta.code.clone();
                 let path = meta.path.clone();
                 let expr = meta.expr.clone();
                 let exports = meta.mem.exports.clone();
                 let index = meta.get_index();
+                let scopes = meta.mem.scopes.clone();
                 // Parse the imported file
                 meta.push_trace(PositionInfo::from_token(meta, tok));
                 meta.path = Some(self.path.value.clone());
                 meta.code = Some(imported_code);
                 meta.expr = tokens;
                 meta.set_index(0);
+                meta.mem.scopes = vec![];
                 syntax(meta, &mut self.block)?;
+                meta.mem.scopes = scopes;
                 self.handle_export(meta, meta.mem.exports.clone());
                 // Restore snapshot of current file
                 meta.code = code;

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -1,0 +1,82 @@
+use heraclitus_compiler::prelude::*;
+use crate::translate::module::TranslateModule;
+use crate::utils::{ParserMetadata, TranslateMetadata};
+use crate::modules::types::Type;
+use crate::modules::block::Block;
+
+use super::variable::variable_name_extensions;
+
+#[derive(Debug, Clone)]
+pub struct Main {
+    pub args: Vec<String>,
+    pub block: Block,
+    pub is_skipped: bool
+}
+
+impl SyntaxModule<ParserMetadata> for Main {
+    syntax_name!("Main");
+
+    fn new() -> Self {
+        Self {
+            args: vec![],
+            block: Block::new(),
+            is_skipped: false
+        }
+    }
+
+    fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        let tok = meta.get_current_token();
+        token(meta, "main")?;
+        // Main cannot be parsed inside of a block
+        if meta.mem.get_depth() > 1 {
+            dbg!(meta.mem.get_depth());
+            return error!(meta, tok, "Main module must be in the global scope")
+        }
+        // If this main is included in other file, skip it
+        if !meta.trace.is_empty() {
+            self.is_skipped = true;
+        }
+        context!({
+            if token(meta, "(").is_ok() {
+                loop {
+                    if token(meta, ")").is_ok() {
+                        break;
+                    }
+                    self.args.push(variable(meta, variable_name_extensions())?);
+                    match token(meta, ")") {
+                        Ok(_) => break,
+                        Err(_) => token(meta, ",")?
+                    };
+                }
+            }
+            token(meta, "{")?;
+            // Create a new scope for variables
+            meta.mem.push_scope();
+            // Create variables
+            for arg in self.args.iter() {
+                meta.mem.add_variable(arg, Type::Text);
+            }
+            // Parse the block
+            syntax(meta, &mut self.block)?;
+            // Remove the scope made for variables
+            meta.mem.pop_scope();
+            token(meta, "}")?;
+            Ok(())
+        }, |pos| {
+            error_pos!(meta, pos, "Undefined syntax in main block")
+        })
+    }
+}
+
+impl TranslateModule for Main {
+    fn translate(&self, meta: &mut TranslateMetadata) -> String {
+        let variables = self.args.iter().enumerate()
+            .map(|(index, name)| format!("{name}=${}", index + 1))
+            .collect::<Vec<_>>().join("\n");
+        if self.is_skipped {
+            String::new()
+        } else {
+            format!("{variables}\n{}", self.block.translate(meta))
+        }
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,6 +9,7 @@ pub mod loops;
 pub mod function;
 pub mod types;
 pub mod imports;
+pub mod main;
 
 #[macro_export]
 macro_rules! handle_types {

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -30,6 +30,7 @@ use crate::modules::function::{
 use crate::modules::imports::{
     import::Import
 };
+use crate::modules::main::Main;
 
 #[derive(Debug, Clone)]
 pub enum StatementType {
@@ -48,7 +49,8 @@ pub enum StatementType {
     Break(Break),
     Continue(Continue),
     FunctionDeclaration(FunctionDeclaration),
-    Import(Import)
+    Import(Import),
+    Main(Main)
 }
 
 #[derive(Debug, Clone)]
@@ -61,7 +63,7 @@ impl Statement {
         // Imports
         Import,
         // Functions
-        FunctionDeclaration,
+        FunctionDeclaration, Main,
         // Loops
         InfiniteLoop, Break, Continue,
         // Conditions
@@ -107,18 +109,18 @@ impl SyntaxModule<ParserMetadata> for Statement {
         let mut error = None;
         let statements = self.get_modules();
         for statement in statements {
-            // If the statement is an expression, we want it to not fire it's own error
-            let statement = if let StatementType::Expr(mut expr) = statement {
-                expr.cannot_fail();
-                StatementType::Expr(expr)
-            } else { statement };
             // Try to parse the statement
             match self.parse_match(meta, statement) {
                 Ok(()) => return Ok(()),
-                Err(details) => error = Some(details)
+                Err(failure) => {
+                    match failure {
+                        Failure::Loud(err) => return Err(Failure::Loud(err)),
+                        Failure::Quiet(err) => error = Some(err)
+                    }
+                }
             }
         }
-        Err(error.unwrap())
+        Err(Failure::Quiet(error.unwrap()))
     }
 }
 

--- a/src/utils/memory.rs
+++ b/src/utils/memory.rs
@@ -38,9 +38,9 @@ impl ScopeUnit {
 
 #[derive(Clone, Debug)]
 pub struct Memory {
-    scopes: Vec<ScopeUnit>,
+    pub scopes: Vec<ScopeUnit>,
     // Map of all generated functions based on their invocations
-    function_map: FunctionMap,
+    pub function_map: FunctionMap,
     pub exports: Exports
 }
 
@@ -51,6 +51,10 @@ impl Memory {
             function_map: FunctionMap::new(),
             exports: Exports::new()
         }
+    }
+    
+    pub fn get_depth(&self) -> usize {
+        self.scopes.len()
     }
 
     pub fn push_scope(&mut self) {

--- a/tests/io/print.ab
+++ b/tests/io/print.ab
@@ -1,3 +1,7 @@
 pub fun print(text) {
     $echo {text}$
 }
+
+main {
+    print('Hello, World!')
+}


### PR DESCRIPTION
Main block captures arguments passed to the shell script - this entity is skipped if is imported from other file.

```
main(arg1, arg2) {
    // Code
}
```
The point of argumentless main is to skip some unimportant code in case if this file is imported
```
main {
    // Code
}
```